### PR TITLE
Improve draw_line

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,12 @@ static_assertions = "1"
 
 [dev-dependencies]
 rand = "0.7"
+criterion = "0.3"
 
 [[test]]
 name = "test"
+harness = false
+
+[[bench]]
+name = "debug_lines"
 harness = false

--- a/benches/debug_lines.rs
+++ b/benches/debug_lines.rs
@@ -1,0 +1,39 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use crow::{
+    glutin::{EventsLoop, WindowBuilder},
+    Context,
+};
+
+fn debug_lines(c: &mut Criterion) {
+    let mut ctx = Context::new(
+        WindowBuilder::new()
+            .with_dimensions(From::from((720, 480)))
+            .with_visibility(false),
+        EventsLoop::new(),
+    )
+    .unwrap();
+
+    let mut surface = ctx.window_surface();
+
+    c.bench_function("debug_lines", |b| {
+        b.iter(|| {
+            ctx.clear_color(&mut surface, (0.0, 0.0, 0.0, 1.0)).unwrap();
+
+            for i in (0..100).map(|i| i * 2) {
+                ctx.draw_line(
+                    &mut surface,
+                    (i, i + 10),
+                    (i + 20, i + 10),
+                    (1.0, 0.0, 1.0, 1.0),
+                )
+                .unwrap();
+            }
+
+            ctx.finalize_frame().unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, debug_lines);
+criterion_main!(benches);

--- a/src/backend/draw.rs
+++ b/src/backend/draw.rs
@@ -1,5 +1,3 @@
-use std::mem;
-
 use gl::types::*;
 
 use crate::{
@@ -58,19 +56,14 @@ impl Backend {
         s.update_viewport_dimensions(target_dimensions);
         s.disable_depth();
         s.update_debug_line_color(color);
+        let data = (
+            (from.0 as f32 + 0.5) / target_dimensions.0 as f32 * 2.0 - 1.0,
+            (from.1 as f32 + 0.5) / target_dimensions.1 as f32 * 2.0 - 1.0,
+            (to.0 as f32 + 0.5) / target_dimensions.0 as f32 * 2.0 - 1.0,
+            (to.1 as f32 + 0.5) / target_dimensions.1 as f32 * 2.0 - 1.0,
+        );
+        s.update_debug_line_start_end(data);
         unsafe {
-            let data: [GLfloat; 4] = [
-                (from.0 as f32 + 0.5) / target_dimensions.0 as f32 * 2.0 - 1.0,
-                (from.1 as f32 + 0.5) / target_dimensions.1 as f32 * 2.0 - 1.0,
-                (to.0 as f32 + 0.5) / target_dimensions.0 as f32 * 2.0 - 1.0,
-                (to.1 as f32 + 0.5) / target_dimensions.1 as f32 * 2.0 - 1.0,
-            ];
-            gl::BufferSubData(
-                gl::ARRAY_BUFFER,
-                0,
-                mem::size_of_val(&data) as _,
-                &data as *const _ as *const _,
-            );
             gl::DrawArrays(gl::LINES, 0, 2);
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -110,11 +110,12 @@ impl Backend {
         }
 
         let (program, uniforms) = Program::new()?;
-        let (lines_program, line_color_uniform) = LinesProgram::new()?;
+        let (lines_program, line_color_uniform, start_end_uniform) = LinesProgram::new()?;
 
         let state = OpenGlState::new(
             uniforms,
             line_color_uniform,
+            start_end_uniform,
             (program.id, program.vao),
             gl_window
                 .window()

--- a/src/backend/shader/mod.rs
+++ b/src/backend/shader/mod.rs
@@ -188,8 +188,8 @@ impl Drop for Program {
 
 #[rustfmt::skip]
 static LINES_VERTEX_DATA: [GLfloat; 4] = [
-    0.0, 0.0,
-    1.0, 1.0,
+    1.0, 0.0,
+    0.0, 1.0,
 ];
 
 #[derive(Debug)]
@@ -200,7 +200,7 @@ pub struct LinesProgram {
 }
 
 impl LinesProgram {
-    pub fn new() -> Result<(Self, GLint), ErrDontCare> {
+    pub fn new() -> Result<(Self, GLint, GLint), ErrDontCare> {
         let program = compile_program(
             include_str!("vertex_lines.glsl"),
             include_str!("fragment_lines.glsl"),
@@ -251,6 +251,14 @@ impl LinesProgram {
             panic!("unknown uniform: {}", name_str)
         }
 
+        let name_str = "start_end";
+        let name = CString::new(name_str).unwrap();
+        let start_end = unsafe { gl::GetUniformLocation(program, name.as_ptr()) };
+
+        if start_end == -1 {
+            panic!("unknown uniform: {}", name_str)
+        }
+
         Ok((
             Self {
                 id: program,
@@ -259,6 +267,7 @@ impl LinesProgram {
                 vbo,
             },
             color_uniform,
+            start_end,
         ))
     }
 }

--- a/src/backend/shader/vertex_lines.glsl
+++ b/src/backend/shader/vertex_lines.glsl
@@ -2,6 +2,8 @@
 
 in vec2 position;
 
+uniform vec4 start_end;
+
 void main() {
-    gl_Position = vec4(position, 0.0, 1.0);
+    gl_Position = vec4(start_end.xy * position.x + start_end.zw * position.y, 0.0, 1.0);
 }

--- a/src/backend/state.rs
+++ b/src/backend/state.rs
@@ -6,6 +6,7 @@ use crate::{backend::shader::Uniforms, color, BlendMode};
 pub struct OpenGlState {
     uniforms: Uniforms,
     debug_lines_color_uniform: GLint,
+    debug_lines_start_end_uniform: GLint,
     program: GLuint,
     target_dimensions: (u32, u32),
     viewport_dimensions: (u32, u32),
@@ -24,12 +25,14 @@ pub struct OpenGlState {
     flip_vertically: bool,
     flip_horizontally: bool,
     debug_line_color: (f32, f32, f32, f32),
+    debug_line_start_end: (f32, f32, f32, f32),
 }
 
 impl OpenGlState {
     pub fn new(
         uniforms: Uniforms,
         debug_lines_color_uniform: GLint,
+        debug_lines_start_end_uniform: GLint,
         (program, vao): (GLuint, GLuint),
         window_dimensions: (u32, u32),
     ) -> Self {
@@ -112,6 +115,7 @@ impl OpenGlState {
             Self {
                 uniforms,
                 debug_lines_color_uniform,
+                debug_lines_start_end_uniform,
                 program,
                 target_dimensions,
                 viewport_dimensions,
@@ -130,6 +134,7 @@ impl OpenGlState {
                 flip_vertically,
                 flip_horizontally,
                 debug_line_color: (0.0, 0.0, 0.0, 0.0),
+                debug_line_start_end: (std::f32::MIN, std::f32::MIN, std::f32::MIN, std::f32::MIN),
             }
         }
     }
@@ -343,6 +348,20 @@ impl OpenGlState {
                 debug_line_color.1,
                 debug_line_color.2,
                 debug_line_color.3,
+            );
+        }
+    }
+    pub fn update_debug_line_start_end(&mut self, debug_line_start_end: (f32, f32, f32, f32)) {
+        if debug_line_start_end != self.debug_line_start_end {
+            self.debug_line_start_end = debug_line_start_end;
+        }
+        unsafe {
+            gl::Uniform4f(
+                self.debug_lines_start_end_uniform,
+                debug_line_start_end.0,
+                debug_line_start_end.1,
+                debug_line_start_end.2,
+                debug_line_start_end.3,
             );
         }
     }


### PR DESCRIPTION
Instead of updating the vertex array buffer each time a line is drawn,
update a vec4 uniform with the content (from.x, from.y, to.x, to.y). Causes a speedup of about 25 %